### PR TITLE
uuid added in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   validators: 
   rxdart: ^0.27.4
   google_fonts: ^3.0.1
+  uuid: ^3.0.6
 dev_dependencies:
   build_runner: ^2.1.11
   freezed: ^2.0.3+1


### PR DESCRIPTION
In `lib/core/constants/value_object.dart` , package [uuid](https://pub.dev/packages/uuid) is imported and used but not added in `pubspec.yaml` file.

Fixed by adding `uuid`s latest version to `pubspec.yaml`